### PR TITLE
Add mass edit confirmation

### DIFF
--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -47,6 +47,7 @@
             var sabSpeedHistory = [$bytespersec_list];
             var newRelease = "$new_release";
             var newReleaseUrl = "$new_rel_url";
+            var confirmMassEdit = $confirm_mass_edit;
             var glitterIsBeta = ("$version".search(/[develop|Alpha|Beta|RC]/)) > 0;
 
             var glitterTranslate = new Object();
@@ -74,6 +75,7 @@
             glitterTranslate.noLocalStorage = "$T('Glitter-noLocalStorage')";
             glitterTranslate.glitterTips = "$T('Glitter-glitterTips')";
             glitterTranslate.updateAvailable = "$T('Glitter-updateAvailable')";
+            glitterTranslate.massEditWarning = "$T('Glitter-massEditWarning')";
             glitterTranslate.defaultText = "$T('default')";
             glitterTranslate.noneText = "$T('None')";
             glitterTranslate.moreText = "$T('Glitter-more')";

--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -320,6 +320,10 @@ function HistoryListModel(parent) {
 
     // Check all
     self.checkAllJobs = function(item, event) {
+        if(self.parent.confirmMassEdit() && !confirm(glitterTranslate.massEditWarning)) {
+            event.target.checked = !event.target.checked;
+            return false;
+        }
         // Get which ones we care about
         var allChecks = $('.history-table input[name="multiedit"]').filter(':not(:disabled):visible');
 

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -18,6 +18,7 @@ function ViewModel() {
     self.displayFullWidth = ko.observable(false).extend({ persist: 'displayFullWidth' });
     self.confirmDeleteQueue = ko.observable(true).extend({ persist: 'confirmDeleteQueue' });
     self.confirmDeleteHistory = ko.observable(true).extend({ persist: 'confirmDeleteHistory' });
+    self.confirmMassEdit = ko.observable(Boolean(confirmMassEdit));
     self.keyboardShortcuts = ko.observable(true).extend({ persist: 'keyboardShortcuts' });
     self.extraQueueColumns = ko.observableArray([]).extend({ persist: 'extraColumns' });
     self.extraHistoryColumns = ko.observableArray([]).extend({ persist: 'extraHistoryColumns' });

--- a/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
@@ -312,6 +312,10 @@ function QueueListModel(parent) {
 
     // Check all
     self.checkAllJobs = function(item, event) {
+        if(self.parent.confirmMassEdit() && !confirm(glitterTranslate.massEditWarning)) {
+            event.target.checked = !event.target.checked;
+            return false;
+        }
         // Get which ones we care about
         var allChecks = $('.queue-table input[name="multiedit"]').filter(':not(:disabled):visible');
 

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -506,6 +506,7 @@ x_frame_options = OptionBool("misc", "x_frame_options", True)
 allow_old_ssl_tls = OptionBool("misc", "allow_old_ssl_tls", False)
 enable_season_sorting = OptionBool("misc", "enable_season_sorting", True)
 verify_xff_header = OptionBool("misc", "verify_xff_header", False)
+confirm_mass_edit = OptionBool("misc", "confirm_mass_edit", True)
 
 # Text values
 rss_odd_titles = OptionList("misc", "rss_odd_titles", ["nzbindex.nl/", "nzbindex.com/", "nzbclub.com/"])

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -464,6 +464,7 @@ class MainPage:
             info["cpumodel"] = get_cpu_name()
             info["cpusimd"] = sabnzbd.decoder.SABCTOOLS_SIMD
             info["platform"] = sabnzbd.PLATFORM
+            info["confirm_mass_edit"] = int(cfg.confirm_mass_edit())
 
             # Have logout only with HTML and if inet=5, only when we are external
             info["have_logout"] = (
@@ -896,6 +897,7 @@ SPECIAL_BOOL_LIST = (
     "allow_old_ssl_tls",
     "enable_season_sorting",
     "verify_xff_header",
+    "confirm_mass_edit",
 )
 SPECIAL_VALUE_LIST = (
     "downloader_sleep_time",

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -868,6 +868,8 @@ SKIN_TEXT = {
     "Glitter-speed": TT("Speed"),
     "Glitter-confirmDeleteQueue": TT("Confirm Queue Deletions"),
     "Glitter-confirmDeleteHistory": TT("Confirm History Deletions"),
+    "Glitter-confirmMassEdit": TT("Confirm mass changes"),
+    "Glitter-massEditWarning": TT("Are you sure you want to modify all items?"),
     "Glitter-keyboardShortcuts": TT("Keyboard shortcuts"),
     "Glitter-keyboardShortcuts-arrows": TT("Shift+Arrow key: Browse Queue and History pages"),
     "Glitter-pausePrompt": TT("How long or untill when do you want to pause? (in English!)"),


### PR DESCRIPTION
## Summary
- add `confirm_mass_edit` option
- expose option to Glitter UI
- warn before checking all items in multi-edit
- translate new mass edit strings

## Testing
- `python3 tools/make_mo.py`
- `pytest -k lang -q`

------
https://chatgpt.com/codex/tasks/task_e_68569428a4448324b0a88ce8182d3dc6