### PR TITLE
Add configurable history status marking

### DIFF
--- a/interfaces/Glitter/templates/include_history.tmpl
+++ b/interfaces/Glitter/templates/include_history.tmpl
@@ -95,7 +95,19 @@
                                     <div class="col-sm-2">$T('status')</div>
                                     <div class="col-sm-10">
                                         <span data-bind="text: glitterTranslate.status[historyStatus.status()] ? glitterTranslate.status[historyStatus.status()] : statusText()"></span>
-                                        <a href="#" class="mark-completed-link" data-bind="visible: failed(), click: markAsCompleted" title="$T('button-mark-completed')"><span class="glyphicon glyphicon-ok"></span> $T('post-Completed')</a>
+                                        <!-- ko if: canMarkStatus() -->
+                                        <span class="history-status-actions" data-bind="visible: parent.markStatusOptions().length === 1">
+                                            <a href="#" class="mark-completed-link" data-bind="click: applyMarkStatus, attr: { title: parent.markStatusTooltip(selectedMarkStatus()) }">
+                                                <span class="glyphicon glyphicon-ok"></span> <span data-bind="text: parent.statusLabel(selectedMarkStatus())"></span>
+                                            </a>
+                                        </span>
+                                        <span class="history-status-actions" data-bind="visible: parent.markStatusOptions().length > 1">
+                                            <select class="history-status-select" data-bind="options: parent.markStatusOptions, optionsText: parent.statusLabel, value: selectedMarkStatus"></select>
+                                            <a href="#" class="mark-completed-link" data-bind="click: applyMarkStatus, attr: { title: parent.markStatusTooltip(selectedMarkStatus()) }">
+                                                <span class="glyphicon glyphicon-ok"></span> $T('button-mark-status')
+                                            </a>
+                                        </span>
+                                        <!-- /ko -->
                                     </div>
                                 </div>
                                 <div class="row">

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -49,7 +49,7 @@
             var newReleaseUrl = "$new_rel_url";
             var confirmMassEditQueue = $confirm_mass_edit_queue;
             var confirmMassEditHistory = $confirm_mass_edit_history;
-            var historyMarkStatuses = $history_mark_statuses;
+            var historyMarkStatuses = "$history_mark_statuses";
             var glitterIsBeta = ("$version".search(/[develop|Alpha|Beta|RC]/)) > 0;
 
             var glitterTranslate = new Object();

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -49,6 +49,7 @@
             var newReleaseUrl = "$new_rel_url";
             var confirmMassEditQueue = $confirm_mass_edit_queue;
             var confirmMassEditHistory = $confirm_mass_edit_history;
+            var historyMarkStatuses = $history_mark_statuses;
             var glitterIsBeta = ("$version".search(/[develop|Alpha|Beta|RC]/)) > 0;
 
             var glitterTranslate = new Object();
@@ -63,6 +64,7 @@
             glitterTranslate.repair = "$T('explain-Repair')".replace(/<br \/>/g, "\n").replace(/&quot;/g,'"');
             glitterTranslate.confirm = "$T('confirm')";
             glitterTranslate.markComplete = "$T('button-mark-completed')";
+            glitterTranslate.markStatusConfirm = "$T('confirm-mark-status')";
             glitterTranslate.renameAbort = "$T('Glitter-confirmAbortDirectUnpack')\n$T('confirm')";
             glitterTranslate.retryAll = "$T('link-retryAll')?";
             glitterTranslate.fetch = "$T('Glitter-fetch')";

--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -20,9 +20,14 @@ function HistoryListModel(parent) {
     self.pagination = new paginationModel(self);
     self.isMultiEditing = ko.observable(false).extend({ persist: 'historyIsMultiEditing' });
     self.multiEditItems = ko.observableArray([]);
-    self.markStatusOptions = ko.observableArray(
-        Array.isArray(historyMarkStatuses) && historyMarkStatuses.length ? historyMarkStatuses : ['Completed']
-    );
+    var parsedMarkStatuses = [];
+    if(typeof historyMarkStatuses === 'string' && historyMarkStatuses.trim() !== '') {
+        parsedMarkStatuses = historyMarkStatuses.split(/\s*,\s*/).filter(Boolean);
+    }
+    if(parsedMarkStatuses.length === 0) {
+        parsedMarkStatuses = ['Completed'];
+    }
+    self.markStatusOptions = ko.observableArray(parsedMarkStatuses);
 
     self.statusLabel = function(status) {
         return glitterTranslate.status[status] ? glitterTranslate.status[status] : status;

--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -20,6 +20,20 @@ function HistoryListModel(parent) {
     self.pagination = new paginationModel(self);
     self.isMultiEditing = ko.observable(false).extend({ persist: 'historyIsMultiEditing' });
     self.multiEditItems = ko.observableArray([]);
+    self.markStatusOptions = ko.observableArray(
+        Array.isArray(historyMarkStatuses) && historyMarkStatuses.length ? historyMarkStatuses : ['Completed']
+    );
+
+    self.statusLabel = function(status) {
+        return glitterTranslate.status[status] ? glitterTranslate.status[status] : status;
+    };
+
+    self.markStatusTooltip = function(status) {
+        if(status === 'Completed') {
+            return glitterTranslate.markComplete;
+        }
+        return glitterTranslate.markStatusConfirm.replace('%s', self.statusLabel(status));
+    };
 
     // Download history info
     self.downloadedToday = ko.observable();
@@ -451,10 +465,13 @@ function HistoryListModel(parent) {
     }
 
     // Mark jobs as completed
-    self.markAsCompleted = function(items) {
-        // Confirm
-        if(!confirm(glitterTranslate.markComplete)) {
-            return
+    self.markAsStatus = function(items, status) {
+        var selectedStatus = status || 'Completed';
+        var confirmText = selectedStatus === 'Completed'
+            ? glitterTranslate.markComplete
+            : glitterTranslate.markStatusConfirm.replace('%s', self.statusLabel(selectedStatus));
+        if(!confirm(confirmText)) {
+            return;
         }
         // Single or multiple items?
         var strIDs = '';
@@ -470,11 +487,17 @@ function HistoryListModel(parent) {
         callAPI({
             mode: 'history',
             name: 'mark_as_completed',
-            value: strIDs
+            value: strIDs,
+            status: selectedStatus
         }).then(function(response) {
             // Force refresh to update the UI
             self.parent.refresh(true);
         });
+    }
+
+    // Mark jobs as completed
+    self.markAsCompleted = function(items) {
+        self.markAsStatus(items, 'Completed');
     }
 
     // Mark all selected as completed
@@ -584,6 +607,17 @@ function HistoryModel(parent, data) {
         return self.script_line();
     });
 
+    self.selectedMarkStatus = ko.observable(parent.markStatusOptions()[0] || 'Completed');
+    self.canMarkStatus = ko.pureComputed(function() {
+        return self.failed() && parent.markStatusOptions().length > 0;
+    });
+
+    parent.markStatusOptions.subscribe(function(options) {
+        if(options.indexOf(self.selectedMarkStatus()) === -1) {
+            self.selectedMarkStatus(options[0] || 'Completed');
+        }
+    });
+
     // Extra history columns
     self.showColumn = function(param) {
         // Picked anything?
@@ -640,6 +674,10 @@ function HistoryModel(parent, data) {
     // Mark as completed button
     self.markAsCompleted = function() {
         parent.markAsCompleted(self);
+    };
+
+    self.applyMarkStatus = function() {
+        parent.markAsStatus(self, self.selectedMarkStatus());
     };
 
     // Update information only on click

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -101,6 +101,7 @@ _MSG_NO_PATH = "file does not exist"
 _MSG_OUTPUT_FORMAT = "Format not supported"
 _MSG_NO_SUCH_CONFIG = "Config item does not exist"
 _MSG_CONFIG_LOCKED = "Configuration locked"
+_MSG_BAD_STATUS = "invalid status"
 
 
 def api_handler(kwargs: Dict[str, Union[str, List[str]]]) -> bytes:
@@ -534,11 +535,19 @@ def _api_history_delete(value: str, kwargs: Dict[str, Union[str, List[str]]]) ->
 def _api_history_mark_as_completed(value: str, kwargs: Dict[str, Union[str, List[str]]]) -> bytes:
     """API: accepts value(=nzo_id)"""
     if value:
+        status = (kwargs.get("status") or Status.COMPLETED).strip()
+        allowed_statuses = set(cfg.history_mark_statuses())
+        allowed_statuses.add(Status.COMPLETED)
+        if status not in allowed_statuses:
+            return report(_MSG_BAD_STATUS)
+
         history_db = sabnzbd.get_db_connection()
         for job in clean_comma_separated_list(value):
-            # Get incomplete path before marking as completed
-            incomplete_path = history_db.get_incomplete_path(job)
-            history_db.mark_as_completed(job)
+            incomplete_path = None
+            if status == Status.COMPLETED:
+                # Get incomplete path before marking as completed
+                incomplete_path = history_db.get_incomplete_path(job)
+            history_db.mark_as_status(job, status)
 
             # Remove incomplete folder if it exists
             if incomplete_path:

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -52,6 +52,7 @@ from sabnzbd.constants import (
     DEF_STD_WEB_COLOR,
     DEF_HTTPS_CERT_FILE,
     DEF_HTTPS_KEY_FILE,
+    Status,
 )
 from sabnzbd.filesystem import same_directory, real_path, is_valid_script, is_network_path
 
@@ -120,6 +121,21 @@ def supported_unrar_parameters(value: str) -> ValidateResult:
             logging.error(msg)
             return msg, None
     return None, value
+
+
+def clean_history_mark_statuses(value: List[str]) -> ValidateResult:
+    """Clean custom history status labels."""
+    cleaned = []
+    for item in value:
+        if item is None:
+            continue
+        label = str(item).strip()
+        if not label or label in cleaned:
+            continue
+        cleaned.append(label)
+    if not cleaned:
+        cleaned = [Status.COMPLETED]
+    return None, cleaned
 
 
 def all_lowercase(value: Union[str, List]) -> Tuple[None, Union[str, List]]:
@@ -509,6 +525,12 @@ enable_season_sorting = OptionBool("misc", "enable_season_sorting", True)
 verify_xff_header = OptionBool("misc", "verify_xff_header", False)
 confirm_mass_edit_queue = OptionBool("misc", "confirm_mass_edit_queue", False)
 confirm_mass_edit_history = OptionBool("misc", "confirm_mass_edit_history", False)
+history_mark_statuses = OptionList(
+    "misc",
+    "history_mark_statuses",
+    [Status.COMPLETED],
+    validation=clean_history_mark_statuses,
+)
 
 # Text values
 rss_odd_titles = OptionList("misc", "rss_odd_titles", ["nzbindex.nl/", "nzbindex.com/", "nzbclub.com/"])

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -234,8 +234,12 @@ class HistoryDB:
 
     def mark_as_completed(self, job: str):
         """Mark a job as completed in the history"""
-        self.execute("""UPDATE history SET status = ? WHERE nzo_id = ?""", (Status.COMPLETED, job))
-        logging.info("[%s] Marked job %s as completed", caller_name(), job)
+        self.mark_as_status(job, Status.COMPLETED)
+
+    def mark_as_status(self, job: str, status: str):
+        """Mark a job as a specific status in the history"""
+        self.execute("""UPDATE history SET status = ? WHERE nzo_id = ?""", (status, job))
+        logging.info("[%s] Marked job %s as %s", caller_name(), job, status)
 
     def get_failed_paths(self, search: Optional[str] = None) -> List[str]:
         """Return list of all storage paths of failed jobs (may contain non-existing or empty paths)"""

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -31,7 +31,6 @@ import socket
 import ssl
 import functools
 import copy
-import json
 from random import randint
 from xml.sax.saxutils import escape
 from Cheetah.Template import Template
@@ -464,7 +463,7 @@ class MainPage:
             info["platform"] = sabnzbd.PLATFORM
             info["confirm_mass_edit_queue"] = int(cfg.confirm_mass_edit_queue())
             info["confirm_mass_edit_history"] = int(cfg.confirm_mass_edit_history())
-            info["history_mark_statuses"] = json.dumps(cfg.history_mark_statuses())
+            info["history_mark_statuses"] = cfg.history_mark_statuses.get_string()
 
             # Have logout only with HTML and if inet=5, only when we are external
             info["have_logout"] = (

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -31,6 +31,7 @@ import socket
 import ssl
 import functools
 import copy
+import json
 from random import randint
 from xml.sax.saxutils import escape
 from Cheetah.Template import Template
@@ -463,6 +464,7 @@ class MainPage:
             info["platform"] = sabnzbd.PLATFORM
             info["confirm_mass_edit_queue"] = int(cfg.confirm_mass_edit_queue())
             info["confirm_mass_edit_history"] = int(cfg.confirm_mass_edit_history())
+            info["history_mark_statuses"] = json.dumps(cfg.history_mark_statuses())
 
             # Have logout only with HTML and if inet=5, only when we are external
             info["have_logout"] = (
@@ -923,6 +925,7 @@ SPECIAL_LIST_LIST = (
     "host_whitelist",
     "local_ranges",
     "ext_rename_ignore",
+    "history_mark_statuses",
 )
 
 

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -172,6 +172,8 @@ SKIN_TEXT = {
     "name": TT("Name"),  #: Queue page table column header
     "button-retry": TT("Retry"),  #: Queue page button
     "button-mark-completed": TT("Mark as Completed & Remove Temporary Files"),  #: History page button
+    "button-mark-status": TT("Set status"),  #: History page button
+    "confirm-mark-status": TT("Change status to %s?"),  #: History page confirmation popup
     "eoq-scripts": TT("Scripts"),  #: Queue page table, script selection menu
     "purgeQueue": TT("Purge Queue"),  #: Queue page button
     "purgeQueueConf": TT("Delete all items from the queue?"),  #: Confirmation popup


### PR DESCRIPTION
### Motivation
- Extend the existing "Mark as Completed" feature so History details can set other custom statuses selectable from the UI while preserving upstream compatibility.

### Description
- Add a new config option `history_mark_statuses` (`OptionList`) and validator `clean_history_mark_statuses` in `sabnzbd/cfg.py` to store a configurable list of status labels and default to `Status.COMPLETED` when empty.
- Expose the configured statuses to the client by adding `info["history_mark_statuses"] = json.dumps(cfg.history_mark_statuses())` in `MainPage.index` and wire `historyMarkStatuses` into the Glitter template (`interfaces/Glitter/templates/main.tmpl`).
- Client-side UI/JS changes in `interfaces/Glitter/templates/static/javascripts/glitter.history.js` and `interfaces/Glitter/templates/include_history.tmpl` add `markStatusOptions`, a status selector, and new functions `markAsStatus`, `applyMarkStatus` (and keep `markAsCompleted` as a wrapper) to send a `status` parameter with the existing `mark_as_completed` API call; helper `statusLabel`/`markStatusTooltip` and translation keys were added to `sabnzbd/skintext.py` and templates to preserve localized labels.
- Backend changes in `sabnzbd/database.py` add `mark_as_status(job, status)` and make `mark_as_completed` call it, and `sabnzbd/api.py`'s `_api_history_mark_as_completed` now accepts and validates an optional `status` (default `Completed`) against the configured list and only removes the incomplete folder when the status is `Completed`; an `_MSG_BAD_STATUS` error string was added for invalid status values.

### Testing
- Started the application with `python SABnzbd.py --config-file /tmp/sabnzbd.ini --server 0.0.0.0:8080` which launched the web UI and background services (succeeded).
- Inserted a test history row into the test DB with `sqlite3 /tmp/admin/history1.db` and verified the row exists (succeeded).
- Queried the history API with the instance API key via `curl` and received JSON history data (succeeded).
- Attempted to capture a UI screenshot with Playwright to validate the dropdown flow, but the headless Chromium process crashed (SIGSEGV) so the UI screenshot test failed; no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f443d83848324b1c8689e2d1918eb)